### PR TITLE
feat: add practical data splitting and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,32 @@ In 5 tests of training the model, the average metrics are as follows:
 
 The model has a high accuracy and low mean squared error, but the F1 score is lower than desired. This is likely due to the class imbalance in the data. The model is predicting that most students will not attend a career fair, which is accurate, but it is not predicting that many students will attend a career fair, which is not accurate. This is likely due to the fact that the model is not taking into account any information specific to the student or any time dependencies in the data.
 
+## Second Implementation
+
+In the first implementation we used the entire data set to both train and test the model. This is not realistic because in practice we would not have access to the data for the career fair we are trying to predict attendance for. In the second implementation we will split the data up into two separate test data sets, one for evaluating the model and one for testing the model with new data. We do this to simulate a real world scenario to see if the model can apply to new data.
+
+### Issues
+
+Since the data is split into two separate data sets the features of the training and testing sets will be different. For example, with categorical data like majors if a major appears in the training dataset but not in the testing dataset (i.e., there was no student in winter 2024 with that same major), there will be a feature mismatch which causes an error.
+
+To overcome this, feature alignment had to be implemented. This goes through each feature of the two datasets and adds any missing from the other so the features are the same and can be compared.
+
+### Data Cleaning
+
+- The data is split into two separate data sets, one for training and one for practical testing
+- The training data contains all career fair attendance data up to the 2024 winter career fair
+- The practical testing data contains the career fair attendance data for the 2024 winter career fair
+- The training and testing data are cleaned in the same way as the first implementation, then feature aligned
+- The training data is split into training and testing sets (test size = 0.2)
+
+### Hyperparameters
+
+- The hyperparameters are the same as the first implementation
+
+### Results
+
+![](https://i.imgur.com/xovOkSg.png)
+
+As we can see, the results with the training data are very similar to the first implementation. However, the model did not fit very well for the new data. With an accuracy of 0.5604, this is only slightly better than random chance.
+
+This could be due to the fact that the model is not taking into account any information specific to the student or any time dependencies in the data.

--- a/decision_tree.py
+++ b/decision_tree.py
@@ -1,10 +1,12 @@
 import time
 from hyperparameters import implementation_1_hyperparameters
 from preprocessing import (
+    get_practical_test,
     load_data,
     clean_data,
-    extract_features_target,
-    split_data
+    # extract_features_target,
+    # split_data,
+    split_practical_data
 )
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.metrics import (
@@ -21,14 +23,27 @@ from colorama import Fore, Style
 # =============================================================================
 data = load_data()
 cleaned_data = clean_data(data)
-features, target = extract_features_target(cleaned_data)
-x_train, x_test, y_train, y_test = split_data(features, target, 0.2)
+
+# features, target = extract_features_target(cleaned_data)
+# x_train, x_test, y_train, y_test = split_data(features, target, 0.2)
+
+(
+    x_train, x_test,
+    y_train, y_test,
+    x_practical_test, y_practical_test
+) = get_practical_test(
+    cleaned_data,
+    'Winter Career Fair 2024',
+    0.2
+)
+
 
 # =============================================================================
 #                           Initialize metrics
 # =============================================================================
 model_count = 5
 avg_accuracy, avg_mse, avg_f1, avg_recall, avg_precision = 0, 0, 0, 0, 0
+avg_practical_accuracy, avg_practical_mse, avg_practical_f1, avg_positive_predicted = 0, 0, 0, 0
 time_elapsed = 0
 start_time = time.time()
 
@@ -59,17 +74,66 @@ def evaluate_model(
     return mse, accuracy, f1, recall, precision, time_taken
 
 
-def print_metrics(mse, accuracy, f1, recall, precision):
-    print(f'{Fore.BLUE}    Mean Squared Error: '
-          f'{Fore.CYAN}{mse:.4f}' + Style.RESET_ALL)
-    print(f'{Fore.BLUE}    Accuracy: '
-          f'{Fore.CYAN}{accuracy:.4f}' + Style.RESET_ALL)
-    print(f'{Fore.BLUE}    F1 Score: '
-          f'{Fore.CYAN}{f1:.4f}' + Style.RESET_ALL)
-    print(f'{Fore.BLUE}    Recall: '
-          f'{Fore.CYAN}{recall:.4f}' + Style.RESET_ALL)
-    print(f'{Fore.BLUE}    Precision: '
-          f'{Fore.CYAN}{precision:.4f}' + Style.RESET_ALL)
+def evaluate_practical(
+    model: DecisionTreeClassifier,
+    x_test,
+    y_test
+):
+    y_pred = model.predict(x_test)
+
+    mse = mean_squared_error(y_test, y_pred)
+    accuracy = accuracy_score(y_test, y_pred)
+    f1 = f1_score(y_test, y_pred)
+    total_positive_predicted = sum(y_pred)
+
+    return mse, accuracy, f1, total_positive_predicted
+
+
+def print_metrics(
+    mse=None,
+    accuracy=None,
+    f1=None,
+    recall=None,
+    precision=None
+):
+    if mse is not None:
+        if mse > 0.25:
+            print(f'{Fore.RED}    Mean Squared Error: '
+                  f'{Fore.CYAN}{mse:.4f}' + Style.RESET_ALL)
+        else:
+            print(f'{Fore.GREEN}    Mean Squared Error: '
+                  f'{Fore.CYAN}{mse:.4f}' + Style.RESET_ALL)
+
+    if accuracy is not None:
+        if accuracy < 0.75:
+            print(f'{Fore.RED}    Accuracy: '
+                  f'{Fore.CYAN}{accuracy:.4f}' + Style.RESET_ALL)
+        else:
+            print(f'{Fore.GREEN}    Accuracy: '
+                  f'{Fore.CYAN}{accuracy:.4f}' + Style.RESET_ALL)
+
+    if f1 is not None:
+        if f1 < 0.5:
+            print(f'{Fore.RED}    F1 Score: '
+                  f'{Fore.CYAN}{f1:.4f}' + Style.RESET_ALL)
+        else:
+            print(f'{Fore.GREEN}    F1 Score: '
+                  f'{Fore.CYAN}{f1:.4f}' + Style.RESET_ALL)
+
+    if recall is not None:
+        if recall < 0.6:
+            print(f'{Fore.RED}    Recall: '
+                  f'{Fore.CYAN}{recall:.4f}' + Style.RESET_ALL)
+        else:
+            print(f'{Fore.GREEN}    Recall: '
+                  f'{Fore.CYAN}{recall:.4f}' + Style.RESET_ALL)
+    if precision is not None:
+        if precision < 0.6:
+            print(f'{Fore.RED}    Precision: '
+                  f'{Fore.CYAN}{precision:.4f}' + Style.RESET_ALL)
+        else:
+            print(f'{Fore.GREEN}    Precision: '
+                  f'{Fore.CYAN}{precision:.4f}' + Style.RESET_ALL)
 
 
 print(Fore.MAGENTA + f"\nTraining {model_count} models..." + Style.RESET_ALL)
@@ -86,7 +150,7 @@ for i in range(model_count):
         model, x_test, y_test, start_time, time_elapsed
     )
 
-    print_metrics(mse, accuracy, f1, recall, precision)
+    # print_metrics(mse, accuracy, f1, recall, precision)
 
     avg_mse += mse
     avg_accuracy += accuracy
@@ -94,6 +158,18 @@ for i in range(model_count):
     avg_recall += recall
     avg_precision += precision
     time_elapsed += time_taken
+
+    (
+        mse, accuracy, f1, total_positive_predicted
+    ) = evaluate_practical(
+        model, x_practical_test, y_practical_test
+    )
+
+    avg_practical_mse += mse
+    avg_practical_accuracy += accuracy
+    avg_practical_f1 += f1
+    avg_positive_predicted += total_positive_predicted
+
 
 print(Fore.GREEN + f'\nAll models trained and evaluated in '
       f'{Fore.CYAN}{time_elapsed:.2f} seconds' + Style.RESET_ALL)
@@ -106,13 +182,35 @@ print(Fore.RED + "\n--------------------------------" + Style.RESET_ALL)
 print(Fore.RED + "        Average Metrics" + Style.RESET_ALL)
 print(Fore.RED + "--------------------------------" + Style.RESET_ALL)
 
-print(f'{Fore.BLUE}  Mean Squared Error: '
-      f'{Fore.CYAN}{avg_mse/model_count:.4f}' + Style.RESET_ALL)
-print(f'{Fore.BLUE}  Accuracy: '
-      f'{Fore.CYAN}{avg_accuracy/model_count:.4f}' + Style.RESET_ALL)
-print(f'{Fore.BLUE}  F1 Score: '
-      f'{Fore.CYAN}{avg_f1/model_count:.4f}' + Style.RESET_ALL)
-print(f'{Fore.BLUE}  Recall: '
-      f'{Fore.CYAN}{avg_recall/model_count:.4f}' + Style.RESET_ALL)
-print(f'{Fore.BLUE}  Precision: '
-      f'{Fore.CYAN}{avg_precision/model_count:.4f}' + Style.RESET_ALL)
+print_metrics(
+    avg_mse/model_count,
+    avg_accuracy/model_count,
+    avg_f1/model_count,
+    avg_recall/model_count,
+    avg_precision/model_count
+)
+
+# =============================================================================
+#                           Practical test
+# =============================================================================
+
+print(Fore.RED + "\n--------------------------------" + Style.RESET_ALL)
+print(f'{Fore.MAGENTA}     Practical Test Results' + Style.RESET_ALL)
+print(Fore.RED + "--------------------------------" + Style.RESET_ALL)
+
+total_positive_actual = sum(y_practical_test)
+
+print(f'{Fore.LIGHTYELLOW_EX}  Average Predicted Attendance: '
+      f'{Fore.CYAN}{avg_positive_predicted/model_count:.1f}' + Style.RESET_ALL)
+print(f'{Fore.LIGHTYELLOW_EX}  Actual Attendance: '
+      f'{Fore.CYAN}{total_positive_actual}' + Style.RESET_ALL)
+print(f'{Fore.LIGHTYELLOW_EX}  Total Students: '
+      f'{Fore.CYAN}{len(y_practical_test)}{Style.RESET_ALL}\n')
+
+print_metrics(
+    avg_practical_mse/model_count,
+    avg_practical_accuracy/model_count,
+    avg_practical_f1/model_count
+)
+
+print()

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -119,3 +119,71 @@ def split_data(features, target, test_size):
     print(f'{Fore.GREEN}Data split{Style.RESET_ALL}')
 
     return x_train, x_test, y_train, y_test
+
+
+def align_features(train_data: pd.DataFrame, test_data: pd.DataFrame):
+    all_features = set(train_data.columns) | set(test_data.columns)
+    print(f'{Fore.MAGENTA}\nAligning {len(all_features)} features '
+          f'between train and test data{Style.RESET_ALL}')
+
+    train_missing: set = all_features - set(train_data.columns)
+    test_missing: set = all_features - set(test_data.columns)
+    count = len(train_missing) + len(test_missing)
+
+    if len(train_missing) > 0:
+        print(f'  {Fore.LIGHTYELLOW_EX}{len(train_missing)}{Fore.RED} '
+              f'Features missing from training data{Style.RESET_ALL}')
+        train_data = train_data.reindex(columns=all_features, fill_value=0)
+    if len(test_missing) > 0:
+        print(f'  {Fore.LIGHTYELLOW_EX}{len(test_missing)}{Fore.RED} '
+              f'Features missing from testing data{Style.RESET_ALL}')
+        test_data = test_data.reindex(columns=all_features, fill_value=0)
+
+    # Ensure the column are in the same order
+    test_data = test_data[train_data.columns]
+
+    print(f'{Fore.CYAN}{count}{Fore.GREEN} Features aligned{Style.RESET_ALL}')
+
+    return train_data, test_data
+
+
+def split_practical_data(data: pd.DataFrame, test_career_fair_name: str):
+    print(f'{Fore.BLUE}Splitting test and training data by '
+          f'{Fore.CYAN}{test_career_fair_name}{Style.RESET_ALL}')
+
+    training_data = data[
+        (data['career_fair_name'] != test_career_fair_name)
+    ]
+    testing_data = data[
+        (data['career_fair_name'] == test_career_fair_name)
+    ]
+
+    training_data, testing_data = align_features(training_data, testing_data)
+
+    print(f'{Fore.GREEN}Data successfully split into testing and training '
+          f'data by {Fore.CYAN}{test_career_fair_name}{Style.RESET_ALL}')
+
+    return training_data, testing_data
+
+
+def get_practical_test(
+    data: pd.DataFrame,
+    test_career_fair_name: str,
+    test_size: float
+):
+    print(f'{Fore.MAGENTA}\nPreparing practical test data...{Style.RESET_ALL}')
+
+    training_data, testing_data = split_practical_data(
+        data, test_career_fair_name)
+
+    features, target = extract_features_target(training_data)
+    x_practical_test, y_practical_test = extract_features_target(testing_data)
+
+    features, x_practical_test = align_features(features, x_practical_test)
+
+    x_train, x_test, y_train, y_test = split_data(
+        features, target, test_size)
+
+    print(f'{Fore.GREEN}Practical test data prepared{Style.RESET_ALL}')
+
+    return x_train, x_test, y_train, y_test, x_practical_test, y_practical_test


### PR DESCRIPTION
- Add practical data splitting and testing. Remove all winter career fair 2024 attendance from training data and use it to perform a practical test on the model.
- Add documentation for the second implementation
- Add `align_features()`, `split_practical_data()`, `get_practical_test()` to `preprocessing.py`
- Add `print_metrics()`, `evaluate_practical()` to `decision_tree.py`