### PR TITLE
Issue 3 include students without attendance

### DIFF
--- a/decision_tree.py
+++ b/decision_tree.py
@@ -22,11 +22,16 @@ from colorama import Fore, Style
 #                           Load and preprocess data
 # =============================================================================
 
-if 'data/cleaned_data.csv' in os.listdir():
-    cleaned_data = pd.read_csv('data/cleaned_data.csv')
+cleaned_data_file_name = 'cleaned_data.csv'
+
+if 'data' not in os.listdir():
+    os.makedirs('data')
+
+if cleaned_data_file_name in os.listdir('data'):
+    cleaned_data = pd.read_csv(f'data\\{cleaned_data_file_name}')
 else:
     cleaned_data = clean_data(*load_data())
-    cleaned_data.to_csv('data/cleaned_data.csv', index=False)
+    cleaned_data.to_csv(f'data\\{cleaned_data_file_name}', index=False)
 
 # features, target = extract_features_target(cleaned_data)
 # x_train, x_test, y_train, y_test = split_data(features, target, 0.2)

--- a/decision_tree.py
+++ b/decision_tree.py
@@ -1,4 +1,7 @@
+import os
 import time
+
+import pandas as pd
 from hyperparameters import implementation_1_hyperparameters
 from preprocessing import (
     get_practical_test,
@@ -18,7 +21,12 @@ from colorama import Fore, Style
 # =============================================================================
 #                           Load and preprocess data
 # =============================================================================
-cleaned_data = clean_data(*load_data())
+
+if 'data/cleaned_data.csv' in os.listdir():
+    cleaned_data = pd.read_csv('data/cleaned_data.csv')
+else:
+    cleaned_data = clean_data(*load_data())
+    cleaned_data.to_csv('data/cleaned_data.csv', index=False)
 
 # features, target = extract_features_target(cleaned_data)
 # x_train, x_test, y_train, y_test = split_data(features, target, 0.2)

--- a/decision_tree.py
+++ b/decision_tree.py
@@ -1,12 +1,9 @@
-import os
 import time
 
-import pandas as pd
 from hyperparameters import implementation_1_hyperparameters
 from preprocessing import (
     get_practical_test,
     load_data,
-    clean_data,
 )
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.metrics import (
@@ -22,16 +19,7 @@ from colorama import Fore, Style
 #                           Load and preprocess data
 # =============================================================================
 
-cleaned_data_file_name = 'cleaned_data.csv'
-
-if 'data' not in os.listdir():
-    os.makedirs('data')
-
-if cleaned_data_file_name in os.listdir('data'):
-    cleaned_data = pd.read_csv(f'data\\{cleaned_data_file_name}')
-else:
-    cleaned_data = clean_data(*load_data())
-    cleaned_data.to_csv(f'data\\{cleaned_data_file_name}', index=False)
+cleaned_data = load_data()
 
 # features, target = extract_features_target(cleaned_data)
 # x_train, x_test, y_train, y_test = split_data(features, target, 0.2)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -12,6 +12,12 @@ data_directory = 'data'
 
 
 def load_data() -> pd.DataFrame:
+    """
+    Loads and merges data from multiple CSV files to create a cleaned dataset.
+
+    Returns:
+        pd.DataFrame: The cleaned dataset.
+    """
     print(f'{Fore.MAGENTA}\nLoading data...{Style.RESET_ALL}')
 
     if data_directory not in os.listdir():
@@ -180,6 +186,20 @@ def clean_data(
     data: pd.DataFrame,
     career_fair_df: pd.DataFrame
 ) -> pd.DataFrame:
+    """
+    Cleans the data by filling null values, converting Yes/No values to 1/0,
+      converting strings, dates, school years, colleges, majors, and
+      appointments to binary values.
+
+    Args:
+        data (pd.DataFrame): The input DataFrame containing the data to be
+          cleaned.
+        career_fair_df (pd.DataFrame): The DataFrame containing career fair
+          information.
+
+    Returns:
+        pd.DataFrame: The cleaned DataFrame.
+    """
     print(f'{Fore.MAGENTA}\nCleaning data...{Style.RESET_ALL}')
 
     yes_no_columns = [
@@ -624,6 +644,16 @@ def clean_data(
 
 
 def extract_features_target(data):
+    """
+    Extracts features and target from the given data.
+
+    Parameters:
+        data (DataFrame): The input data containing features and target.
+
+    Returns:
+        features (DataFrame): The extracted features from the data.
+        target (Series): The extracted target from the data.
+    """
     print(f'{Fore.MAGENTA}\n  Extracting features and target...'
           f'{Style.RESET_ALL}')
 
@@ -643,6 +673,21 @@ def extract_features_target(data):
 
 
 def split_data(features, target, test_size):
+    """
+    Split the data into training and testing sets.
+
+    Parameters:
+    features (array-like): The input features.
+    target (array-like): The target variable.
+    test_size (float): The proportion of the dataset to include in the test 
+      split.
+
+    Returns:
+    x_train (array-like): The training features.
+    x_test (array-like): The testing features.
+    y_train (array-like): The training target variable.
+    y_test (array-like): The testing target variable.
+    """
     print(f'{Fore.MAGENTA}\n  Splitting data...{Style.RESET_ALL}')
     print(f'{Fore.BLUE}    Test size: {Fore.CYAN}{test_size}{Style.RESET_ALL}')
 
@@ -655,6 +700,17 @@ def split_data(features, target, test_size):
 
 
 def align_features(train_data: pd.DataFrame, test_data: pd.DataFrame):
+    """
+    Aligns the features between the train and test dataframes.
+
+    Args:
+        train_data (pd.DataFrame): The training data.
+        test_data (pd.DataFrame): The testing data.
+
+    Returns:
+        pd.DataFrame, pd.DataFrame: The aligned training and testing 
+          dataframes.
+    """
     all_features = set(train_data.columns) | set(test_data.columns)
     print(f'{Fore.MAGENTA}\n  Aligning {len(all_features)} features '
           f'between train and test data...{Style.RESET_ALL}')
@@ -682,6 +738,19 @@ def align_features(train_data: pd.DataFrame, test_data: pd.DataFrame):
 
 
 def split_practical_data(data: pd.DataFrame, test_career_fair_name: str):
+    """
+    Split the given data into training and testing data based on the specified 
+      test career fair name.
+
+    Parameters:
+        data (pd.DataFrame): The input data to be split.
+        test_career_fair_name (str): The name of the career fair to be used as 
+          the test data.
+
+    Returns:
+        training_data (pd.DataFrame): The training data after splitting.
+        testing_data (pd.DataFrame): The testing data after splitting.
+    """
     print(f'{Fore.BLUE}  Splitting test and training data by '
           f'{Fore.CYAN}{test_career_fair_name}{Style.RESET_ALL}')
 
@@ -711,6 +780,29 @@ def get_practical_test(
     test_career_fair_name: str,
     test_size: float
 ):
+    """
+    Prepare practical test data for the Career Fair Attendance Classifier.
+
+    Args:
+        data (pd.DataFrame): The cleaned input data containing the attendance
+          records.
+        test_career_fair_name (str): The name of the career fair to be used
+          for practical testing.
+        test_size (float): The proportion of the data from 0 to 1 to be used
+          for testing.
+
+    Returns:
+        tuple: A tuple containing the training and testing data for the
+          classifier.
+            - x_train (pd.DataFrame): The features of the training data.
+            - x_test (pd.DataFrame): The features of the testing data.
+            - y_train (pd.Series): The target labels of the training data.
+            - y_test (pd.Series): The target labels of the testing data.
+            - x_practical_test (pd.DataFrame): The features of the practical
+              test data.
+            - y_practical_test (pd.Series): The target labels of the practical
+              test data.
+    """
     print(f'{Fore.MAGENTA}\nPreparing practical test data...{Style.RESET_ALL}')
 
     training_data, testing_data = split_practical_data(

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -8,74 +8,234 @@ from colorama import Fore, Style
 
 
 def load_data():
-    print(Fore.MAGENTA + "\nLoading data..." + Style.RESET_ALL)
+    print(f'{Fore.MAGENTA}\nLoading data...{Style.RESET_ALL}')
 
     appointment_df = pd.read_csv('data/appointment_data.csv')
-    attendance_df = pd.read_csv('data/attendance_data.csv')
     career_fair_df = pd.read_csv('data/career_fair_data.csv')
     registration_df = pd.read_csv('data/registration_data.csv')
     student_df = pd.read_csv('data/student_data.csv')
+    stu_counts_1_df = pd.read_csv('data/student_counts_1.csv')
+    stu_counts_2_df = pd.read_csv('data/student_counts_2.csv')
 
-    print(Fore.GREEN + "Data loaded" + Style.RESET_ALL)
+    print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} csv files loaded'
+          f'{Style.RESET_ALL}')
 
-    merged_data = pd.merge(student_df, registration_df,
+    # ===============================================================
+    #                          Merge Data
+    # ===============================================================
+
+    # There should be a row for each career fair for every student.
+    #   If the student never attended a career fair, there will be
+    #   a row with all null values for that student.
+    #
+    # The appointment_df only contains rows for students that have
+    #   appointments. There can only be one row per student however,
+    #   so we will just need to merge the appointment data with the
+    #   student data to ensure that we have a row for each student.
+    #
+    # The registration_df contains a row for each student that has
+    #   registered for each career fair. There may be multiple rows
+    #   for each student. We want a row for every student for every
+    #   career fair, so we will need to merge the registration data
+    #   with the student data.
+
+    merged_data = pd.merge(student_df, stu_counts_1_df,
+                           on='stu_id', how='left')
+    merged_data = pd.merge(merged_data, stu_counts_2_df,
                            on='stu_id', how='left')
     merged_data = pd.merge(merged_data, appointment_df,
                            on='stu_id', how='left')
-    merged_data = pd.merge(
-        merged_data,
-        attendance_df,
-        on=[
-            'stu_id', 'career_fair_name', 'career_fair_date'
+
+    print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} Student data merged'
+          f'{Style.RESET_ALL}')
+
+    # To ensure that we have a row for each student for each career fair,
+    #   we get the cross product of the student ids and career fair dates
+    #   and merge that with the merged data. This ensures there is a row
+    #   for each student for each career fair.
+    # Then, we merge the registration data with all that to add the
+    #   registration columns to the merged data.
+
+    # Merge career fair name and date to ensure that we have a unique
+    #   identifier for each career fair (some have the same name but
+    #   different dates)
+    registration_df['career_fair_id'] = (
+        registration_df['career_fair_name'] +
+        ' ' +
+        registration_df['career_fair_date']
+    )
+    career_fair_df['career_fair_id'] = (
+        career_fair_df['career_fair_name'] +
+        ' ' +
+        career_fair_df['career_fair_date']
+    )
+    career_fair_simple = career_fair_df[[
+        'career_fair_id',
+        'career_fair_name',
+        'career_fair_date'
+    ]]
+
+    # Drop the original columns, they will be merged back later
+    registration_df.drop(
+        columns=[
+            'career_fair_name',
+            'career_fair_date'
         ],
+        inplace=True
+    )
+
+    print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} Generated unique career fair '
+          f'id\'s{Style.RESET_ALL}')
+
+    # Merge student data with career fair data
+
+    stu_fair_combinations = pd.merge(
+        student_df[['stu_id']],
+        pd.DataFrame(
+            registration_df['career_fair_id'].unique(),
+            columns=['career_fair_id']
+        ),
+        how='cross'
+    )
+
+    print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} Generated student/career fair '
+          f'combinations{Style.RESET_ALL}')
+
+    merged_data = pd.merge(
+        stu_fair_combinations, merged_data,
+        on=['stu_id'],
+        how='left'
+    )
+    print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} Student/Career Fair data merged'
+          f'{Style.RESET_ALL}')
+
+    # Merge back in the career fair data
+
+    merged_data = pd.merge(
+        merged_data, career_fair_simple,
+        on='career_fair_id',
         how='left'
     )
 
-    print(Fore.GREEN + "Data merged" + Style.RESET_ALL)
+    print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} Career Fair data merged'
+          f'{Style.RESET_ALL}')
+
+    # Merge the registration data
+    merged_data = pd.merge(
+        merged_data, registration_df,
+        on=['stu_id', 'career_fair_id'],
+        how='left'
+    )
+    print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} Career Fair Registration '
+          f'data merged'
+          f'{Style.RESET_ALL}')
+
+    print(f'{Fore.LIGHTBLACK_EX}  ⓘ {Fore.BLUE} Rows: '
+          f'{Fore.LIGHTBLACK_EX}{len(merged_data)}'
+          f'{Style.RESET_ALL}')
+    print(f'{Fore.LIGHTBLACK_EX}  ⓘ {Fore.BLUE} Students: '
+          f'{Fore.LIGHTBLACK_EX}{len(merged_data["stu_id"].unique())}'
+          f'{Style.RESET_ALL}')
+
+    merged_data.drop(
+        [
+            'appointment_count',
+            'stu_id',
+            'career_fair_id',
+        ], axis=1, inplace=True)
+
+    print(f'{Fore.LIGHTBLACK_EX}  ⓘ {Fore.BLUE} Columns: '
+          f'{Fore.LIGHTBLACK_EX}{merged_data.columns}'
+          f'{Style.RESET_ALL}')
+
+    print(f'{Fore.GREEN}✓{Fore.MAGENTA} Data merged{Style.RESET_ALL}')
 
     return merged_data, career_fair_df
 
 
 def clean_data(data, career_fair_df):
-    print(Fore.MAGENTA + "\nCleaning data..." + Style.RESET_ALL)
+    print(f'{Fore.MAGENTA}\nCleaning data...{Style.RESET_ALL}')
+
+    yes_no_columns = [
+        'is_pre_registered',
+        'is_checked_in',
+        'stu_is_activated',
+        'stu_is_visible',
+        'stu_is_archived',
+        'stu_is_work_study',
+        'stu_is_profile_complete'
+    ]
+
+    count_columns = [
+        'stu_appointments',
+        'stu_applications',
+        'stu_attendances',
+        'stu_work_experiences',
+        'stu_experiences',
+        'stu_logins'
+    ]
+
+    # ===============================================================
+    #                          Null Values
+    # ===============================================================
+
+    print(f'{Fore.LIGHTBLACK_EX}  → {Fore.BLUE}Filling null values...'
+          f'{Style.RESET_ALL}')
+
+    for column in yes_no_columns:
+        data[column] = data[column].fillna('No')
+
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Null Yes/No values filled '
+          f'with \'No\'{Style.RESET_ALL}')
+
+    for column in count_columns:
+        data[column] = data[column].fillna(0)
+
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Null count values filled '
+          f'with 0{Style.RESET_ALL}')
+
+    data['stu_colleges'] = data['stu_colleges'].fillna('No College Designated')
+
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} All null values filled'
+          f'{Style.RESET_ALL}')
 
     # Convert Yes/No to 1/0
 
-    data['is_checked_in'] = data['is_checked_in'].apply(
-        lambda x: 1 if x == 'Yes' else 0)
-    data['is_pre_registered'] = data['is_pre_registered'].apply(
-        lambda x: 1 if x == 'Yes' else 0)
-    data['stu_is_activated'] = data['stu_is_activated'].apply(
-        lambda x: 1 if x == 'Yes' else 0)
-    data['stu_is_visible'] = data['stu_is_visible'].apply(
-        lambda x: 1 if x == 'Yes' else 0)
+    print(f'{Fore.LIGHTBLACK_EX}  → {Fore.BLUE}Converting Yes/No values to '
+          f'1/0...{Style.RESET_ALL}')
 
-    print(Fore.BLUE + "  Yes/No converted to 1/0" + Style.RESET_ALL)
+    for column in yes_no_columns:
+        data[column] = data[column].apply(
+            lambda x: 1 if x == 'Yes' else 0)
+
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Yes/No converted to 1/0'
+          f'{Style.RESET_ALL}')
 
     # ===============================================================
     #                       Integer Conversion
     # ===============================================================
 
     # Convert any strings in the form '1,000' to integers
-    # while keeping existing integers
-    data['appointment_count'] = data['appointment_count'].apply(
-        lambda x: int(x.replace(',', '')) if isinstance(x, str) else x)
-    data['stu_applications'] = data['stu_applications'].apply(
-        lambda x: int(x.replace(',', '')) if isinstance(x, str) else x)
-    data['stu_logins'] = data['stu_logins'].apply(
-        lambda x: int(x.replace(',', '')) if isinstance(x, str) else x)
-    data['stu_attendances'] = data['stu_attendances'].apply(
-        lambda x: int(x.replace(',', '')) if isinstance(x, str) else x)
+    #   while keeping existing integers
 
-    print(Fore.BLUE + "  Strings converted to integers" + Style.RESET_ALL)
+    print(f'{Fore.LIGHTBLACK_EX}  → {Fore.BLUE}Converting strings to binary '
+          f'values...{Style.RESET_ALL}')
+
+    for column in count_columns:
+        data[column] = data[column].apply(
+            lambda x: int(x.replace(',', '')) if isinstance(x, str) else x)
+
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Strings converted to integers'
+          f'{Style.RESET_ALL}')
 
     # Convert integers to binary thresholds values
     #   and drop the original columns
-    data['has_appointment'] = data['appointment_count'].apply(
+
+    data['has_appointment'] = data['stu_appointments'].apply(
         lambda x: 1 if x > 0 else 0)
-    data['has_5_appointments'] = data['appointment_count'].apply(
+    data['has_5_appointments'] = data['stu_appointments'].apply(
         lambda x: 1 if x >= 5 else 0)
-    data['has_10_appointments'] = data['appointment_count'].apply(
+    data['has_10_appointments'] = data['stu_appointments'].apply(
         lambda x: 1 if x >= 10 else 0)
     data['has_application'] = data['stu_applications'].apply(
         lambda x: 1 if x > 0 else 0)
@@ -95,85 +255,155 @@ def clean_data(data, career_fair_df):
         lambda x: 1 if x >= 5 else 0)
     data['has_10_attendances'] = data['stu_attendances'].apply(
         lambda x: 1 if x >= 10 else 0)
+    data['has_work_experience'] = data['stu_work_experiences'].apply(
+        lambda x: 1 if x > 0 else 0)
+    data['has_2_work_experiences'] = data['stu_work_experiences'].apply(
+        lambda x: 1 if x >= 2 else 0)
+    data['has_3_work_experiences'] = data['stu_work_experiences'].apply(
+        lambda x: 1 if x >= 3 else 0)
+    data['has_experience'] = data['stu_experiences'].apply(
+        lambda x: 1 if x > 0 else 0)
+    data['has_2_experiences'] = data['stu_experiences'].apply(
+        lambda x: 1 if x >= 2 else 0)
+    data['has_3_experiences'] = data['stu_experiences'].apply(
+        lambda x: 1 if x >= 3 else 0)
 
-    data.drop([
-        'appointment_count',
-        'stu_applications',
-        'stu_logins',
-        'stu_attendances'
-    ], axis=1, inplace=True)
+    data.drop(count_columns, axis=1, inplace=True)
 
-    print(f"{Fore.BLUE}  Integers converted to binary values{Style.RESET_ALL}")
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Integers converted to binary '
+          f'values{Style.RESET_ALL}')
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} All strings converted to '
+          f'binary values{Style.RESET_ALL}')
 
     # ===============================================================
     #                      Date Conversion
     # ===============================================================
 
-    # Date between stu_created and career_fair_date
+    print(f'{Fore.LIGHTBLACK_EX}  → {Fore.BLUE}Converting dates to binary '
+          f'values...{Style.RESET_ALL}')
+
+    # Date between stu_creation_date and career_fair_date
     data['days_since_created'] = (pd.to_datetime(data['career_fair_date']) -
-                                  pd.to_datetime(data['stu_created'])).dt.days
-    data['created_1_year_pre_cf'] = data['days_since_created'] <= 365
-    data['created_2_years_pre_cf'] = data['days_since_created'] <= 730
-    data['created_3_years_pre_cf'] = data['days_since_created'] <= 1095
-    data['created_4_years_pre_cf'] = data['days_since_created'] > 1095
+                                  pd.to_datetime(data['stu_creation_date'])
+                                  ).dt.days
+    data['created_1_year_pre_cf'] = data['days_since_created'].apply(
+        lambda x: 1 if x <= 365 else 0)
+    data['created_2_years_pre_cf'] = data['days_since_created'].apply(
+        lambda x: 1 if x <= 730 else 0)
+    data['created_3_years_pre_cf'] = data['days_since_created'].apply(
+        lambda x: 1 if x <= 1095 else 0)
+    data['created_4_years_pre_cf'] = data['days_since_created'].apply(
+        lambda x: 1 if x <= 1825 else 0)
+    data['created_5_years_pre_cf'] = data['days_since_created'].apply(
+        lambda x: 1 if x > 1825 else 0)
 
-    data.drop(['stu_created', 'days_since_created'], axis=1, inplace=True)
+    data.drop(['stu_creation_date', 'days_since_created'],
+              axis=1, inplace=True)
 
-    # Date between stu_login and career_fair_date
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Creation date converted to '
+          f'binary values{Style.RESET_ALL}')
+
+    # Date between stu_login_date and career_fair_date
     data['days_since_login'] = (pd.to_datetime(data['career_fair_date']) -
-                                pd.to_datetime(data['stu_login'])).dt.days
-    data['login_7_days_pre_cf'] = data['days_since_login'] <= 7
-    data['login_30_days_pre_cf'] = data['days_since_login'] <= 30
-    data['login_90_days_pre_cf'] = data['days_since_login'] <= 90
-    data['login_90+_days_pre_cf'] = data['days_since_login'] > 90
+                                pd.to_datetime(data['stu_login_date'])
+                                ).dt.days
+    data['login_7_days_pre_cf'] = data['days_since_login'].apply(
+        lambda x: 1 if x <= 7 else 0)
+    data['login_30_days_pre_cf'] = data['days_since_login'].apply(
+        lambda x: 1 if x <= 30 else 0)
+    data['login_90_days_pre_cf'] = data['days_since_login'].apply(
+        lambda x: 1 if x <= 90 else 0)
+    data['login_90+_days_pre_cf'] = data['days_since_login'].apply(
+        lambda x: 1 if x > 90 else 0)
 
-    data.drop(['stu_login', 'days_since_login'], axis=1, inplace=True)
+    data.drop(['stu_login_date', 'days_since_login'], axis=1, inplace=True)
+
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Login date converted to '
+          f'binary values{Style.RESET_ALL}')
 
     # Date between stu_grad_date and career_fair_date
     data['days_until_grad'] = (pd.to_datetime(data['stu_grad_date']) -
                                pd.to_datetime(data['career_fair_date'])
                                ).dt.days
 
-    data['grad_1_year_post_cf'] = data['days_until_grad'] <= 365
-    data['grad_2_years_post_cf'] = data['days_until_grad'] <= 730
-    data['grad_3_years_post_cf'] = data['days_until_grad'] <= 1095
-    data['grad_4_years_post_cf'] = data['days_until_grad'] > 1095
+    data['grad_1_year_post_cf'] = data['days_until_grad'].apply(
+        lambda x: 1 if x <= 365 else 0)
+    data['grad_2_years_post_cf'] = data['days_until_grad'].apply(
+        lambda x: 1 if x <= 730 else 0)
+    data['grad_3_years_post_cf'] = data['days_until_grad'].apply(
+        lambda x: 1 if x <= 1095 else 0)
+    data['grad_4_years_post_cf'] = data['days_until_grad'].apply(
+        lambda x: 1 if x > 1095 else 0)
 
-    data.drop(['stu_grad_date', 'days_until_grad'], axis=1, inplace=True)
+    data.drop(['days_until_grad'], axis=1, inplace=True)
 
-    print(Fore.BLUE + "  Dates converted to binary values" + Style.RESET_ALL)
+    # data.drop(['career_fair_date'], axis=1, inplace=True)
+
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Graduation date converted to '
+          f'binary values{Style.RESET_ALL}')
+
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} All dates converted to '
+          f'binary values{Style.RESET_ALL}')
 
     # ===============================================================
     #                       School Year Cleaning
     # ===============================================================
 
-    # Convert school year to a binary value
+    # Convert school year to a binary value. stu_school_year is a list
+    #   of school years
+
+    print(f'{Fore.LIGHTBLACK_EX}  → {Fore.BLUE}Extracting student school '
+          f'years...{Style.RESET_ALL}')
+
+    data['stu_school_year'] = data['stu_school_year'].apply(
+        lambda x: x.split(',') if isinstance(x, str) else x
+    )
+    data['stu_school_year'] = data['stu_school_year'].apply(
+        lambda x: x if isinstance(x, list) else []
+    )
 
     data['is_freshman'] = data['stu_school_year'].apply(
-        lambda x: 1 if x == 'Freshman' else 0)
+        lambda x: 1 if 'Freshman' in x else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted Freshmen '
+          f'{Style.RESET_ALL}')
     data['is_sophomore'] = data['stu_school_year'].apply(
-        lambda x: 1 if x == 'Sophomore' else 0)
+        lambda x: 1 if 'Sophomore' in x else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted Sophomores '
+          f'{Style.RESET_ALL}')
     data['is_junior'] = data['stu_school_year'].apply(
-        lambda x: 1 if x == 'Junior' else 0)
+        lambda x: 1 if 'Junior' in x else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted Juniors '
+          f'{Style.RESET_ALL}')
     data['is_senior'] = data['stu_school_year'].apply(
-        lambda x: 1 if x == 'Senior' else 0)
+        lambda x: 1 if 'Senior' in x else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted Seniors '
+          f'{Style.RESET_ALL}')
     data['is_alumni'] = data['stu_school_year'].apply(
-        lambda x: 1 if x == 'Alumni' else 0)
+        lambda x: 1 if 'Alumni' in x else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted Alumni '
+          f'{Style.RESET_ALL}')
     data['is_masters'] = data['stu_school_year'].apply(
-        lambda x: 1 if x == 'Masters' else 0)
+        lambda x: 1 if 'Masters' in x else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted Masters Students '
+          f'{Style.RESET_ALL}')
     data['is_doctorate'] = data['stu_school_year'].apply(
-        lambda x: 1 if x == 'Doctorate' else 0)
+        lambda x: 1 if 'Doctorate' in x else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted Doctoral Students '
+          f'{Style.RESET_ALL}')
 
     data.drop(['stu_school_year'], axis=1, inplace=True)
 
-    print(f"{Fore.BLUE}  School year converted to binary values"
-          f"{Style.RESET_ALL}")
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} All School years converted '
+          f'to binary values{Style.RESET_ALL}')
 
     # ===============================================================
     #                       College Cleaning
     # ===============================================================
 
-    # convert colleges to a list of colleges
+    print(f'{Fore.LIGHTBLACK_EX}  → {Fore.BLUE}Extracting student '
+          f'colleges...{Style.RESET_ALL}')
+
+    # Convert colleges to a list of colleges
 
     data['stu_colleges'] = data['stu_colleges'].apply(
         lambda x: x.split(',') if isinstance(x, str) else x
@@ -198,24 +428,41 @@ def clean_data(data, career_fair_df):
 
     data['is_engineering'] = data['stu_colleges'].apply(
         lambda x: 1 if any([college in engineering for college in x]) else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted engineering '
+          f'binary values{Style.RESET_ALL}')
     data['is_business'] = data['stu_colleges'].apply(
         lambda x: 1 if any([college in business for college in x]) else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted business '
+          f'binary values{Style.RESET_ALL}')
     data['is_health'] = data['stu_colleges'].apply(
         lambda x: 1 if any([college in health for college in x]) else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted health '
+          f'binary values{Style.RESET_ALL}')
     data['is_education'] = data['stu_colleges'].apply(
         lambda x: 1 if any([college in education for college in x]) else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted education '
+          f'binary values{Style.RESET_ALL}')
     data['is_arts'] = data['stu_colleges'].apply(
         lambda x: 1 if any([college in arts for college in x]) else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted arts '
+          f'binary values{Style.RESET_ALL}')
     data['no_college'] = data['stu_colleges'].apply(
         lambda x: 1 if any([college in no_college for college in x]) else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted no college '
+          f'binary values{Style.RESET_ALL}')
     data['multiple_colleges'] = data['stu_colleges'].apply(
         lambda x: 1 if len(x) > 1 else 0)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted multiple colleges '
+          f'binary values{Style.RESET_ALL}')
     data['other_college'] = data['stu_colleges'].apply(
         lambda x: 0 if any(college in all_colleges for college in x) else 1)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Extracted other colleges '
+          f'binary values{Style.RESET_ALL}')
 
     data.drop(['stu_colleges'], axis=1, inplace=True)
 
-    print(f"{Fore.BLUE}  Colleges converted to binary values{Style.RESET_ALL}")
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} All colleges converted to '
+          f'binary values{Style.RESET_ALL}')
 
     # ===============================================================
     #                        Majors Cleaning
@@ -224,7 +471,8 @@ def clean_data(data, career_fair_df):
     # Add a column for whether the student has a major that is
     #   included in the career fair they attended
 
-    print(Fore.BLUE + "  Extracting student majors..." + Style.RESET_ALL)
+    print(f'{Fore.LIGHTBLACK_EX}  → {Fore.BLUE}Extracting student '
+          f'majors...{Style.RESET_ALL}')
 
     # First ensure that stu_majors only contains lists
 
@@ -243,7 +491,8 @@ def clean_data(data, career_fair_df):
 
     data.drop(['stu_majors'], axis=1, inplace=True)
 
-    print(Fore.GREEN + "  Majors converted to binary values" + Style.RESET_ALL)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} All majors converted to '
+          f'binary values{Style.RESET_ALL}')
 
     # ===============================================================
     #                       Appointments Cleaning
@@ -256,7 +505,8 @@ def clean_data(data, career_fair_df):
     # Appointment Types included: Walk-Ins, Resume Reviews, Career Fair
     #   Preparation, Career Exploration, Internship/Job Search, and Other.
 
-    print(Fore.BLUE + "  Extracting appointment types..." + Style.RESET_ALL)
+    print(f'{Fore.LIGHTBLACK_EX}  → {Fore.BLUE}Extracting appointment '
+          f'types...{Style.RESET_ALL}')
 
     # First ensure that appointment_types only contains lists of
     #   lowercase strings
@@ -276,7 +526,8 @@ def clean_data(data, career_fair_df):
         lambda x: [i for i in x if 'walk-in' not in i]
     )
 
-    print(Fore.BLUE + "    Walk-Ins extracted" + Style.RESET_ALL)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Walk-Ins extracted'
+          f'{Style.RESET_ALL}')
 
     # Resume Reviews
     data['has_resume_review'] = data['appointment_types'].apply(
@@ -286,7 +537,8 @@ def clean_data(data, career_fair_df):
         lambda x: [i for i in x if 'resume' not in i]
     )
 
-    print(Fore.BLUE + "    Resume Reviews extracted" + Style.RESET_ALL)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Resume Reviews extracted'
+          f'{Style.RESET_ALL}')
 
     # Career Fair Prep
     data['has_cf_prep'] = data['appointment_types'].apply(
@@ -296,7 +548,8 @@ def clean_data(data, career_fair_df):
         lambda x: [i for i in x if 'career fair' not in i]
     )
 
-    print(Fore.BLUE + "    Career Fair Prep extracted" + Style.RESET_ALL)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Career Fair Prep extracted'
+          f'{Style.RESET_ALL}')
 
     # Career Exploration
     data['has_career_exploration'] = data['appointment_types'].apply(
@@ -306,7 +559,8 @@ def clean_data(data, career_fair_df):
         lambda x: [i for i in x if 'career exploration' not in i]
     )
 
-    print(Fore.BLUE + "    Career Exploration extracted" + Style.RESET_ALL)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Career Exploration extracted'
+          f'{Style.RESET_ALL}')
 
     # Internship/Job Search
     data['has_job_search'] = data['appointment_types'].apply(
@@ -316,64 +570,68 @@ def clean_data(data, career_fair_df):
         lambda x: [i for i in x if 'internship' not in i and 'job' not in i]
     )
 
-    print(Fore.BLUE + "    Internship/Job Search extracted" + Style.RESET_ALL)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Internship/Job Search '
+          f'extracted{Style.RESET_ALL}')
 
     # Other
     data['has_other'] = data['appointment_types'].apply(
         lambda x: 1 if len(x) > 0 else 0
     )
 
-    print(Fore.BLUE + "    Other extracted" + Style.RESET_ALL)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Other extracted'
+          f'{Style.RESET_ALL}')
 
     # Drop appointment_types since we've extracted the binary values
     data.drop(['appointment_types'], axis=1, inplace=True)
 
-    print(Fore.GREEN + "  Appointments cleaned" + Style.RESET_ALL)
+    print(f'{Fore.GREEN}    ✓{Fore.LIGHTCYAN_EX} Appointments cleaned'
+          f'{Style.RESET_ALL}')
 
-    # ===============================================================
-    #                          Null Values
-    # ===============================================================
+    print(f'{Fore.GREEN}✓{Fore.MAGENTA} Data cleaned{Style.RESET_ALL}')
 
-    # Fill null values with 0
-    data.fillna(0, inplace=True)
-
-    print(Fore.GREEN + "Data cleaned" + Style.RESET_ALL)
+    print(f'{Fore.LIGHTBLACK_EX}  ⓘ {Fore.BLUE} Data: '
+          f'{Fore.LIGHTBLACK_EX}{len(data)}{Style.RESET_ALL}')
+    print(f'{Fore.LIGHTBLACK_EX}  ⓘ {Fore.BLUE} Features: '
+          f'{Fore.LIGHTBLACK_EX}{len(data.columns) - 1}{Style.RESET_ALL}')
 
     return data
 
 
 def extract_features_target(data):
-    print(f'{Fore.MAGENTA}\nExtracting features and target...'
+    print(f'{Fore.MAGENTA}\n  Extracting features and target...'
           f'{Style.RESET_ALL}')
 
     features = data.drop(
-        ['stu_id', 'is_checked_in', 'career_fair_name', 'career_fair_date'],
+        [
+            'is_checked_in',
+        ],
         axis=1
     )
 
     target = data['is_checked_in']
 
-    print(f'{Fore.GREEN}Features and target extracted{Style.RESET_ALL}')
+    print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} '
+          f'Features and target extracted{Style.RESET_ALL}')
 
     return features, target
 
 
 def split_data(features, target, test_size):
-    print(Fore.MAGENTA + "\nSplitting data..." + Style.RESET_ALL)
-    print(f"{Fore.BLUE}  Test size: {Fore.CYAN}{test_size}" + Style.RESET_ALL)
+    print(f'{Fore.MAGENTA}\n  Splitting data...{Style.RESET_ALL}')
+    print(f'{Fore.BLUE}    Test size: {Fore.CYAN}{test_size}{Style.RESET_ALL}')
 
     x_train, x_test, y_train, y_test = train_test_split(
         features, target, test_size=test_size, random_state=0)
 
-    print(f'{Fore.GREEN}Data split{Style.RESET_ALL}')
+    print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} Data split{Style.RESET_ALL}')
 
     return x_train, x_test, y_train, y_test
 
 
 def align_features(train_data: pd.DataFrame, test_data: pd.DataFrame):
     all_features = set(train_data.columns) | set(test_data.columns)
-    print(f'{Fore.MAGENTA}\nAligning {len(all_features)} features '
-          f'between train and test data{Style.RESET_ALL}')
+    print(f'{Fore.MAGENTA}\n  Aligning {len(all_features)} features '
+          f'between train and test data...{Style.RESET_ALL}')
 
     train_missing: set = all_features - set(train_data.columns)
     test_missing: set = all_features - set(test_data.columns)
@@ -391,26 +649,33 @@ def align_features(train_data: pd.DataFrame, test_data: pd.DataFrame):
     # Ensure the column are in the same order
     test_data = test_data[train_data.columns]
 
-    print(f'{Fore.CYAN}{count}{Fore.GREEN} Features aligned{Style.RESET_ALL}')
+    print(f'{Fore.GREEN}  ✓{Fore.CYAN} {count}{Fore.LIGHTCYAN_EX} Features '
+          f'aligned{Style.RESET_ALL}')
 
     return train_data, test_data
 
 
 def split_practical_data(data: pd.DataFrame, test_career_fair_name: str):
-    print(f'{Fore.BLUE}Splitting test and training data by '
+    print(f'{Fore.BLUE}  Splitting test and training data by '
           f'{Fore.CYAN}{test_career_fair_name}{Style.RESET_ALL}')
 
-    training_data = data[
-        (data['career_fair_name'] != test_career_fair_name)
-    ]
-    testing_data = data[
-        (data['career_fair_name'] == test_career_fair_name)
-    ]
+    data.drop(
+        columns=['career_fair_date', 'stu_grad_date'],
+        axis=1,
+        inplace=True
+    )
+
+    training_data = data[data['career_fair_name'] != test_career_fair_name]
+    testing_data = data[data['career_fair_name'] == test_career_fair_name]
+
+    training_data = training_data.drop(columns=['career_fair_name'], axis=1)
+    testing_data = testing_data.drop(columns=['career_fair_name'], axis=1)
 
     training_data, testing_data = align_features(training_data, testing_data)
 
-    print(f'{Fore.GREEN}Data successfully split into testing and training '
-          f'data by {Fore.CYAN}{test_career_fair_name}{Style.RESET_ALL}')
+    print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} Data successfully split into '
+          f'testing and training data by '
+          f'{Fore.CYAN}{test_career_fair_name}{Style.RESET_ALL}')
 
     return training_data, testing_data
 
@@ -433,6 +698,15 @@ def get_practical_test(
     x_train, x_test, y_train, y_test = split_data(
         features, target, test_size)
 
-    print(f'{Fore.GREEN}Practical test data prepared{Style.RESET_ALL}')
+    print(f'{Fore.GREEN}✓{Fore.MAGENTA} Practical test data prepared'
+          f'{Style.RESET_ALL}')
+    print(f'{Fore.LIGHTBLACK_EX}  ⓘ {Fore.BLUE} Training data: '
+          f'{Fore.LIGHTBLACK_EX}{len(x_train)}{Style.RESET_ALL}')
+    print(f'{Fore.LIGHTBLACK_EX}  ⓘ {Fore.BLUE} Testing data: '
+          f'{Fore.LIGHTBLACK_EX}{len(x_test)}{Style.RESET_ALL}')
+    print(f'{Fore.LIGHTBLACK_EX}  ⓘ {Fore.BLUE} Practical test data: '
+          f'{Fore.LIGHTBLACK_EX}{len(x_practical_test)}{Style.RESET_ALL}')
+    print(f'{Fore.LIGHTBLACK_EX}  ⓘ {Fore.BLUE} Features: '
+          f'{Fore.LIGHTBLACK_EX}{len(features.columns)}{Style.RESET_ALL}')
 
     return x_train, x_test, y_train, y_test, x_practical_test, y_practical_test

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from colorama import Fore, Style
@@ -6,9 +7,24 @@ from colorama import Fore, Style
 #                           Data Preprocessing
 # =============================================================================
 
+cleaned_data_file_name = 'cleaned_data.csv'
+data_directory = 'data'
 
-def load_data():
+
+def load_data() -> pd.DataFrame:
     print(f'{Fore.MAGENTA}\nLoading data...{Style.RESET_ALL}')
+
+    if data_directory not in os.listdir():
+        os.makedirs(data_directory)
+
+    if cleaned_data_file_name in os.listdir(data_directory):
+        print(f'{Fore.LIGHTBLACK_EX}  → {Fore.BLUE}Loading cleaned '
+              f'data...{Style.RESET_ALL}')
+        cleaned_data = pd.read_csv(
+            f'{data_directory}\\{cleaned_data_file_name}')
+        print(f'{Fore.GREEN}  ✓{Fore.LIGHTCYAN_EX} Cleaned data loaded'
+              f'{Style.RESET_ALL}')
+        return cleaned_data
 
     appointment_df = pd.read_csv('data/appointment_data.csv')
     career_fair_df = pd.read_csv('data/career_fair_data.csv')
@@ -150,10 +166,20 @@ def load_data():
 
     print(f'{Fore.GREEN}✓{Fore.MAGENTA} Data merged{Style.RESET_ALL}')
 
-    return merged_data, career_fair_df
+    cleaned_data = clean_data(merged_data, career_fair_df)
+
+    cleaned_data.to_csv(
+        f'{data_directory}\\{cleaned_data_file_name}',
+        index=False
+    )
+
+    return cleaned_data
 
 
-def clean_data(data, career_fair_df):
+def clean_data(
+    data: pd.DataFrame,
+    career_fair_df: pd.DataFrame
+) -> pd.DataFrame:
     print(f'{Fore.MAGENTA}\nCleaning data...{Style.RESET_ALL}')
 
     yes_no_columns = [


### PR DESCRIPTION
Rather than only including students/career fairs that were attended, include a single entry for every career fair for every student.

Major Changes
- Vastly improve inline documentation
- Add detailed, consistent, and easily viewable logging
- Include every career fair
- Include every student
- Add `stu_is_archived`, `stu_is_work_study`, `stu_is_profile_complete`, `stu_work_experiences`, `stu_experiences` columns
- Ensure practical testing data includes all students

Minor Changes
- Ensure only 0 and 1 are used for feature values
- Ensure there are no missing values
- Use school year list rather than single school year
- Load cleaned data from `data/cleaned_data.csv` if it already exists to speed up processing and save cleaned data to `data/cleaned_data.csv` after processing for faster retrieval
- Add docstring to preprocessing functions